### PR TITLE
Add `objectMode` option to stream arrays

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,8 +55,9 @@ You can pass some options to the parser. All of them are optional. Here are the 
   delimiter: ',', // comma, semicolon, whatever
   newline: '\n', // newline character
   quote: '\"', // what's considered a quote
-  empty: '' // empty fields are replaced by this,
-  encoding: '' // the encoding of the source, in case you need to convert it
+  empty: '', // empty fields are replaced by this,
+  encoding: '', // the encoding of the source, in case you need to convert it
+  objectMode: false // emit arrays instead of stringified arrays
 }
 ```
 

--- a/csv-streamify.js
+++ b/csv-streamify.js
@@ -40,6 +40,7 @@ function CSVStream (opts, cb) {
   this.newline = opts.newline || '\n'
   this.quote = opts.quote || '\"'
   this.empty = opts.hasOwnProperty('empty') ? opts.empty : ''
+  this.objectMode = opts.objectMode || false
 
   // state
   this.body = []
@@ -84,8 +85,14 @@ CSVStream.prototype._parse = function (data) {
     if (/*!this.isQuoted && */c === this.newline) {
       this.line.push(this.field)
 
-      // emit the parsed line array as a string
-      this.push(JSON.stringify(this.line))
+      // emit the parsed line as an array if in object mode
+      // or as a stringified array (default)
+      if (this.objectMode) {
+        this.push(this.line)
+      }
+      else {
+        this.push(JSON.stringify(this.line))
+      }
 
       if (this.cb) this.body.push(this.line)
       this.lineNo += 1

--- a/test/csv-streamify.js
+++ b/test/csv-streamify.js
@@ -98,5 +98,24 @@ describe('encoding', function() {
   })
 })
 
+describe('object mode', function() {
+  it('should stream one array per line', function (done) {
+    var count = 0,
+        parser = csv({objectMode: true}),
+        fstream = fs.createReadStream(__dirname + '/fixtures/quote.csv')
 
+    parser.on('readable', function () {
+      assert(Array.isArray(parser.read()))
+      assert.equal(parser.lineNo, count);
+      count += 1
+    })
 
+    parser.on('end', function () {
+      assert.equal(count, 12)
+      assert.equal(parser.lineNo, 12)
+      done()
+    })
+
+    fstream.pipe(parser)
+  })
+})


### PR DESCRIPTION
Pass `{objectMode: true}` as an option to stream array objects instead of JSON.stringified arrays (defaults to stringified).
