### PR TITLE
Send columns names beside the current line

### DIFF
--- a/csv-streamify.js
+++ b/csv-streamify.js
@@ -16,6 +16,7 @@ module.exports = function (opts, cb) {
   opts.empty = opts.hasOwnProperty('empty') ? opts.empty : ''
   opts.objectMode = opts.objectMode || false
   opts.hasColumns = opts.columns || false
+  opts.sendColumns = opts.sendColumns || false
 
   // state
   var state = {
@@ -58,7 +59,11 @@ function createParser (opts, state) {
     // emit the parsed line as an array if in object mode
     // or as a stringified array (default)
     if (opts.objectMode) {
-      parser.push(state._line)
+      if (opts.sendColumns) {
+        parser.push({line: state._line, columns: state._columns})
+      } else {
+        parser.push(state._line)
+      }
     } else {
       parser.push(JSON.stringify(state._line) + '\n')
     }


### PR DESCRIPTION
Added a parameter sendColumns to be able to send the column names beside the current line.