### PR TITLE
Allow custom function to map columns

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,6 +72,8 @@ The options are also passed to the underlying transform stream, so you can pass 
   objectMode: false,
 
   // if set to true, uses first row as keys -> [ { column1: value1, column2: value2 }, ...]
+  // a function can be passed to columns to map the array of columns
+  // columns: (cols) => cols.map(col => col.toLowerCase())
   columns: false
 }
 ```

--- a/csv-streamify.js
+++ b/csv-streamify.js
@@ -11,7 +11,7 @@ var through = require('through2')
  * @param {string} [opts.quote='"'] The quote character
  * @param {string} [opts.empty=''] Which character to return for empty fields
  * @param {boolean} [opts.objectMode=true] Whether to return an object or a buffer per line
- * @param {boolean} [opts.columns=false] Whether to parse headers
+ * @param {boolean|function} [opts.columns=false] Whether to parse headers or a function to parse headers
  * @param {function} [cb] Callback function
  */
 module.exports = function (opts, cb) {
@@ -53,7 +53,11 @@ function createParser (opts, state) {
 
     if (opts.hasColumns) {
       if (state.lineNo === 0) {
-        state._columns = state._line
+        if (typeof opts.hasColumns === 'function') {
+          state._columns = opts.hasColumns(state._line)
+        } else {
+          state._columns = state._line
+        }
         state.lineNo += 1
         reset()
         return

--- a/test/csv-streamify.js
+++ b/test/csv-streamify.js
@@ -157,6 +157,19 @@ describe('object mode', function () {
 
     str('COL0,COL1\ncol0,col1\ncol2,col3').pipe(parser)
   })
+
+  it('should emit multiple columns parsed by custom function', function (done) {
+    var parser = csv({
+      columns: (cols) => cols.map(col => col.toLowerCase())
+    }, function (err, res) {
+      if (err) return done(err)
+      assert.deepEqual(res[0], { col0: 'col0', col1: 'col1' })
+      assert.deepEqual(res[1], { col0: 'col2', col1: 'col3' })
+      done()
+    })
+
+    str('COL0,COL1\ncol0,col1\ncol2,col3').pipe(parser)
+  })
 })
 
 describe('edge cases', function () {


### PR DESCRIPTION
`columns` option now supports either boolean or function.
This function is responsable to map the array of keys of the first column. It receives an array of strings and should return an array of strings.

A simple example would be to lower case the name of the columns
```
const csv = require('csv-streamify')
const parser = csv({
  columns: (cols) => cols.map(col => col.toLowerCase()),
})
```

Another example would be to clean strange characters from row title (like required on https://github.com/klaemo/csv-stream/issues/53)
```
const csv = require('csv-streamify')
const parser = csv({
  columns: (cols) => cols.map(col => col.replace(/[^a-zA-Z0-9_]/g,'')),
})
```

it also covers the proposed in https://github.com/klaemo/csv-stream/pull/40 without the need of creating a new option
```
const parser = csv({
  columns: (cols) => cols.map(name => {
    switch (name) {
      case 'some Weird Name':
        return 'new_name'
      default:
        return name
    }
  })
})
```